### PR TITLE
Increase the byte write delay to support some lower quality eeprom units

### DIFF
--- a/scripts/eeprom_access.py
+++ b/scripts/eeprom_access.py
@@ -87,7 +87,7 @@ class EEPROM_endpoint:
       val = writeBuff[ii]
       if not self.test:
         self.writeByte(val, bank, addr)
-      time.sleep(0.004)
+      time.sleep(0.005)
     self.addLogEntry("WRITE", self.bankList[bank].devAddr, startAddr,
                      length, writeBuff)
 


### PR DESCRIPTION
Currently about 0.5-1.0% of units fail end of line due to failing the EEPROM write test.
In 19/20 of these cases, increasing the write delay from 4ms to 5ms fixed the issue.
This increase in delay doesn't affect the read speed, and doesn't introduce a degradation to existing units that pass at 4ms.
While we lack longitudinal data to determine if a slower write speed EEPROM unit correlates with a shorter lifespan for that component, it may be worthwhile to collect that data to assess.